### PR TITLE
Ci fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   nix-checks:
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -11,6 +11,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -19,6 +19,8 @@ jobs:
       image-id: ${{ steps.get-docker-id.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: DeterminateSystems/nix-installer-action@v4
       - uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Login to ghcr.io
@@ -44,6 +46,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Substitute image tag
         run: |
           IMAGE_TAG=${{needs.docker.outputs.image-id}}


### PR DESCRIPTION
- Limit runtime of nix builds to reasonable numbers, instead of 6 hours
- Run deployment on CI-checked commit, not main HEAD